### PR TITLE
ops: redeploy tokenizer

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,6 +19,7 @@ jobs:
           dockerfile: Dockerfile
       - run: go test -v ./...
 
+  # TODO: this step cannot be rerun after success (tag is immutable in ECR...)
   build-and-push-tokenizer:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
with note about piepline limitation (cannot rerun build if deploy fails
due to ECR tag immutability!)
